### PR TITLE
Fix typo in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ declare module 'leaflet' {
     type fullscreenOptions = FullscreenOptions;
 
     interface Map {
-        isfullscreen(): boolean;
+        isFullscreen(): boolean;
         toggleFullscreen(): void;
     }
 


### PR DESCRIPTION
Based on documentation, the added method to Map is called `isFullscreen` and not `isfullscreen`.